### PR TITLE
fix: this avoid the runtime error due the missing of jwks_url

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,4 @@
 import Config
+
+config :kinde,
+  jwks_url: "https://example.com"

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,11 +2,8 @@ import Config
 
 config :joken_jwks, strategy: Kinde.TestJwksStrategy
 
-config :joken_jwks, Kinde.TokenStrategy,
-  should_start: false,
-  strategy: Kinde.TestJwksStrategy,
-  jwks_url: "https://starfish-dev.eu.kinde.com/.well-known/jwks",
-  log_level: :debug
+config :kinde,
+  jwks_url: "https://example.com"
 
 config :kinde, Kinde,
   plug: {Req.Test, Kinde},

--- a/lib/kinde/application.ex
+++ b/lib/kinde/application.ex
@@ -5,12 +5,14 @@ defmodule Kinde.Application do
 
   use Application
 
+  @jwks_url Application.compile_env!(:kinde, :jwks_url)
+
   @impl true
   def start(_type, _args) do
     children = [
       {Finch, name: KindeFinch},
       Kinde.StateManagementAgent,
-      Kinde.TokenStrategy
+      {Kinde.TokenStrategy, [jwks_url: @jwks_url]}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
To make the `JokenJwks.DefaultStrategyTemplate` be [able to fetch](https://github.com/joken-elixir/joken_jwks/blob/78b530815c02c61bb2cc35698378eef593228d23/lib/joken_jwks/default_strategy_template.ex#L189C21-L189C29) the certificates we need to set the `jwks_url`.  


This PR makes the option required by Kinde library