### PR TITLE
feat(token)!: return full OAuth2 token response instead of user params

### DIFF
--- a/lib/kinde.ex
+++ b/lib/kinde.ex
@@ -29,7 +29,7 @@ defmodule Kinde do
       {:ok, url} = Kinde.auth()
 
       # Step 2: handle the callback
-      {:ok, user, extra_params} = Kinde.token(code, state)
+      {:ok, token_response, extra_params} = Kinde.token(code, state)
   """
 
   alias Kinde.{MissingConfigError, ObtainingTokenError, StateManagement, Token, URL}
@@ -48,6 +48,17 @@ defmodule Kinde do
   @type state_params :: %{
           code_verifier: String.t(),
           extra_params: map()
+        }
+
+  @type token_response :: %{
+          access_token: String.t(),
+          access_token_claims: map(),
+          id_token: String.t(),
+          id_token_claims: map(),
+          refresh_token: String.t(),
+          expires_in: non_neg_integer(),
+          scope: String.t(),
+          token_type: String.t()
         }
 
   @scopes ~w[openid profile email offline]
@@ -101,8 +112,9 @@ defmodule Kinde do
   via JWKS, and returns user attributes along with any `extra_params` that were
   passed to `auth/2`.
 
-  Returns `{:ok, user_params, extra_params}` on success, where `user_params`
-  is a map with keys: `:id`, `:given_name`, `:family_name`, `:email`, `:picture`.
+  Returns `{:ok, token_response, extra_params}` on success, where
+  `token_response` is a `t:token_response/0` map containing the full OAuth2
+  token endpoint response including decoded JWT claims.
 
   ## Errors
 
@@ -111,7 +123,7 @@ defmodule Kinde do
     * `{:error, %MissingConfigError{}}` — required config keys are missing
   """
   @spec token(String.t(), String.t(), config(), Keyword.t()) ::
-          {:ok, map(), map()} | {:error, term()}
+          {:ok, token_response(), map()} | {:error, term()}
   def token(code, state, config \\ %{}, opts \\ []) do
     with {:ok, config} <- load_config_from_app_env(config),
          {:ok, params} <- StateManagement.take_state(state) do
@@ -142,8 +154,8 @@ defmodule Kinde do
     }
 
     with {:ok, response} <- run_request(domain, form, opts),
-         {:ok, claims} <- handle_response(response) do
-      {:ok, user_params(claims), extra_params}
+         {:ok, token_response} <- decode_token_response(response) do
+      {:ok, token_response, extra_params}
     end
   end
 
@@ -156,23 +168,29 @@ defmodule Kinde do
     |> Req.post()
   end
 
-  defp handle_response(%Req.Response{status: 200, body: %{"id_token" => token}}) do
-    Token.verify_and_validate(token)
+  defp decode_token_response(%Req.Response{status: 200, body: body}) do
+    with {:ok, id_token_claims} <- verify_token(body["id_token"]),
+         {:ok, access_token_claims} <- verify_token(body["access_token"]) do
+      {:ok,
+       %{
+         access_token: body["access_token"],
+         access_token_claims: access_token_claims,
+         id_token: body["id_token"],
+         id_token_claims: id_token_claims,
+         refresh_token: body["refresh_token"],
+         expires_in: body["expires_in"],
+         scope: body["scope"],
+         token_type: body["token_type"]
+       }}
+    end
   end
 
-  defp handle_response(%Req.Response{status: status, body: body}) do
+  defp decode_token_response(%Req.Response{status: status, body: body}) do
     {:error, %ObtainingTokenError{status: status, body: body}}
   end
 
-  defp user_params(claims) do
-    %{
-      id: claims["sub"],
-      given_name: claims["given_name"],
-      family_name: claims["family_name"],
-      email: claims["email"],
-      picture: claims["picture"]
-    }
-  end
+  defp verify_token(nil), do: {:ok, %{}}
+  defp verify_token(token), do: Token.verify_and_validate(token)
 
   defp pkce do
     verifier =

--- a/test/kinde_test.exs
+++ b/test/kinde_test.exs
@@ -80,7 +80,14 @@ defmodule KindeTest do
         "picture" => Faker.Internet.url()
       }
 
+      access_token_claims = %{
+        "sub" => kinde_id,
+        "permissions" => ["manage-extensions"],
+        "org_code" => "org_test123"
+      }
+
       {:ok, id_token} = TokenStrategy.sign(claims)
+      {:ok, access_token} = TokenStrategy.sign(access_token_claims)
 
       code = Faker.String.base64()
       state = Faker.String.base64(44)
@@ -94,7 +101,9 @@ defmodule KindeTest do
       %{
         kinde_id: kinde_id,
         claims: claims,
+        access_token_claims: access_token_claims,
         id_token: id_token,
+        access_token: access_token,
         code: code,
         state: state,
         opts: [plug: {Req.Test, Kinde}, retry: false]
@@ -106,22 +115,40 @@ defmodule KindeTest do
       code: code,
       state: state,
       id_token: id_token,
+      access_token: access_token,
       claims: claims,
+      access_token_claims: access_token_claims,
       opts: opts
     } do
       expect(Kinde, fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         assert %{"code" => ^code} = URI.decode_query(body)
-        json(conn, %{"id_token" => id_token})
+
+        json(conn, %{
+          "id_token" => id_token,
+          "access_token" => access_token,
+          "refresh_token" => "test-refresh-token",
+          "expires_in" => 86_399,
+          "scope" => "openid profile email offline",
+          "token_type" => "bearer"
+        })
       end)
 
-      assert {:ok, params, _extra_params} = Kinde.token(code, state, config, opts)
+      assert {:ok, token_response, _extra_params} = Kinde.token(code, state, config, opts)
 
-      assert params[:id] == Map.fetch!(claims, "sub")
-      assert params[:given_name] == Map.fetch!(claims, "given_name")
-      assert params[:family_name] == Map.fetch!(claims, "family_name")
-      assert params[:email] == Map.fetch!(claims, "email")
-      assert params[:picture] == Map.fetch!(claims, "picture")
+      assert token_response.id_token == id_token
+      assert token_response.id_token_claims["sub"] == Map.fetch!(claims, "sub")
+      assert token_response.id_token_claims["given_name"] == Map.fetch!(claims, "given_name")
+      assert token_response.id_token_claims["family_name"] == Map.fetch!(claims, "family_name")
+      assert token_response.id_token_claims["email"] == Map.fetch!(claims, "email")
+      assert token_response.id_token_claims["picture"] == Map.fetch!(claims, "picture")
+      assert token_response.access_token == access_token
+      assert token_response.access_token_claims["sub"] == access_token_claims["sub"]
+      assert token_response.access_token_claims["permissions"] == ["manage-extensions"]
+      assert token_response.refresh_token == "test-refresh-token"
+      assert token_response.expires_in == 86_399
+      assert token_response.scope == "openid profile email offline"
+      assert token_response.token_type == "bearer"
     end
 
     @tag extra_params: %{"token-test" => true}
@@ -131,11 +158,63 @@ defmodule KindeTest do
       code: code,
       state: state,
       id_token: id_token,
+      access_token: access_token,
       extra_params: extra_params
+    } do
+      expect(Kinde, &json(&1, %{"id_token" => id_token, "access_token" => access_token}))
+
+      assert {:ok, _token_response, ^extra_params} = Kinde.token(code, state, config, opts)
+    end
+
+    test "returns empty claims when access_token is absent", %{
+      config: config,
+      opts: opts,
+      code: code,
+      state: state,
+      id_token: id_token,
+      claims: claims
     } do
       expect(Kinde, &json(&1, %{"id_token" => id_token}))
 
-      assert {:ok, _params, ^extra_params} = Kinde.token(code, state, config, opts)
+      assert {:ok, token_response, _extra_params} = Kinde.token(code, state, config, opts)
+
+      assert token_response.id_token_claims["sub"] == Map.fetch!(claims, "sub")
+      assert token_response.access_token == nil
+      assert token_response.access_token_claims == %{}
+    end
+
+    test "returns empty claims when id_token is absent", %{
+      config: config,
+      opts: opts,
+      code: code,
+      state: state,
+      access_token: access_token,
+      access_token_claims: access_token_claims
+    } do
+      expect(Kinde, &json(&1, %{"access_token" => access_token}))
+
+      assert {:ok, token_response, _extra_params} = Kinde.token(code, state, config, opts)
+
+      assert token_response.access_token_claims["sub"] == access_token_claims["sub"]
+      assert token_response.id_token == nil
+      assert token_response.id_token_claims == %{}
+    end
+
+    test "returns nil for missing optional fields", %{
+      config: config,
+      opts: opts,
+      code: code,
+      state: state,
+      id_token: id_token
+    } do
+      expect(Kinde, &json(&1, %{"id_token" => id_token}))
+
+      assert {:ok, token_response, _extra_params} = Kinde.token(code, state, config, opts)
+
+      assert token_response.refresh_token == nil
+      assert token_response.expires_in == nil
+      assert token_response.scope == nil
+      assert token_response.token_type == nil
     end
 
     test "returns error no_token when request for token fails", %{


### PR DESCRIPTION
BREAKING CHANGE: `Kinde.token/4` now returns `{:ok, token_response, extra_params}`
instead of `{:ok, user_params, extra_params}`. The `token_response` map contains
the complete OAuth2 response including raw JWTs, decoded claims for both access
and id tokens, refresh token, expiry, scope, and token type.

Callers must update their pattern match and access user data via
`token_response.id_token_claims` instead of the previous `user_params` map.
